### PR TITLE
Bump dependencies

### DIFF
--- a/unix_user_manager.gemspec
+++ b/unix_user_manager.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.9"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.1.0"
+  spec.add_development_dependency "rake", "~> 12.3.3"
 end


### PR DESCRIPTION
Bump dependencies. Technically not cricical, since we don't rely on it, but good to have